### PR TITLE
Add max, minimum, gamepad speed Overloading to slider.

### DIFF
--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -70,7 +70,7 @@ void MainMenuGeneralView::Draw()
 
     
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 200), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
-    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed * 2, buf);
+    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed * 2.0, buf);
 
     if ((g_config.perf.cpu_clockspeed-0.495)*(g_config.perf.cpu_clockspeed-0.505) <= 0) {g_config.perf.cpu_clockspeed = 0.5;}
     

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -70,7 +70,7 @@ void MainMenuGeneralView::Draw()
 
     
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 200), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
-    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed * 2.0f, buf );
+    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf , 0f, 2f, 0.025f);
 
     if ((g_config.perf.cpu_clockspeed-0.495)*(g_config.perf.cpu_clockspeed-0.505) <= 0) {g_config.perf.cpu_clockspeed = 0.5;}
     
@@ -368,7 +368,7 @@ void MainMenuAudioView::Draw()
     char buf[32];
     snprintf(buf, sizeof(buf), "Limit output volume (%d%%)",
              (int)(g_config.audio.volume_limit * 100));
-    Slider("Output volume limit", &g_config.audio.volume_limit, buf);
+    Slider("Output volume limit", &g_config.audio.volume_limit, buf, 0f, 1f, 0.05f);
 
     SectionTitle("Quality");
     Toggle("Real-time DSP processing", &g_config.audio.use_dsp,

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -70,7 +70,7 @@ void MainMenuGeneralView::Draw()
 
     
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 200), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
-    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf , 0f, 2f, 0.025f);
+    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf , 0, 2, 0.025);
 
     if ((g_config.perf.cpu_clockspeed-0.495)*(g_config.perf.cpu_clockspeed-0.505) <= 0) {g_config.perf.cpu_clockspeed = 0.5;}
     
@@ -368,7 +368,7 @@ void MainMenuAudioView::Draw()
     char buf[32];
     snprintf(buf, sizeof(buf), "Limit output volume (%d%%)",
              (int)(g_config.audio.volume_limit * 100));
-    Slider("Output volume limit", &g_config.audio.volume_limit, buf, 0f, 1f, 0.05f);
+    Slider("Output volume limit", &g_config.audio.volume_limit, buf);
 
     SectionTitle("Quality");
     Toggle("Real-time DSP processing", &g_config.audio.use_dsp,

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -70,7 +70,7 @@ void MainMenuGeneralView::Draw()
 
     
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 200), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
-    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf * 2 );
+    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed * 2.0f, buf );
 
     if ((g_config.perf.cpu_clockspeed-0.495)*(g_config.perf.cpu_clockspeed-0.505) <= 0) {g_config.perf.cpu_clockspeed = 0.5;}
     

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -74,7 +74,7 @@ void MainMenuGeneralView::Draw()
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 100), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
     Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, min , max, gpspeed, buf);
 
-    if ((g_config.perf.cpu_clockspeed-0.495)*(g_config.perf.cpu_clockspeed-0.505) <= 0) {g_config.perf.cpu_clockspeed = 0.5;}
+    if ((g_config.perf.cpu_clockspeed-0.99)*(g_config.perf.cpu_clockspeed-1.01) <= 0) {g_config.perf.cpu_clockspeed = 1;}
     
     SectionTitle("Miscellaneous");
     Toggle("Skip startup animation", &g_config.general.skip_boot_anim,

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -369,7 +369,7 @@ void MainMenuAudioView::Draw()
     SectionTitle("Volume");
     char buf[32];
     float min = 0;
-    float max = 2;
+    float max = 1;
     float gpspeed = 0.05;
     snprintf(buf, sizeof(buf), "Limit output volume (%d%%)",
              (int)(g_config.audio.volume_limit * 100));

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -70,7 +70,7 @@ void MainMenuGeneralView::Draw()
 
     
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 200), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
-    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf , 0, 2, 0.025);
+    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf , 0f, 2f, 0.025f);
 
     if ((g_config.perf.cpu_clockspeed-0.495)*(g_config.perf.cpu_clockspeed-0.505) <= 0) {g_config.perf.cpu_clockspeed = 0.5;}
     

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -69,7 +69,7 @@ void MainMenuGeneralView::Draw()
 
 
     
-    snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 100), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
+    snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 200), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
     Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf);
 
     if ((g_config.perf.cpu_clockspeed-0.495)*(g_config.perf.cpu_clockspeed-0.505) <= 0) {g_config.perf.cpu_clockspeed = 0.5;}

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -72,7 +72,7 @@ void MainMenuGeneralView::Draw()
 
     
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 200), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
-    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, &min , &max, &gpspeed, buf);
+    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, min , max, gpspeed, buf);
 
     if ((g_config.perf.cpu_clockspeed-0.495)*(g_config.perf.cpu_clockspeed-0.505) <= 0) {g_config.perf.cpu_clockspeed = 0.5;}
     
@@ -373,7 +373,7 @@ void MainMenuAudioView::Draw()
     float gpspeed = 0.05;
     snprintf(buf, sizeof(buf), "Limit output volume (%d%%)",
              (int)(g_config.audio.volume_limit * 100));
-    Slider("Output volume limit", &g_config.audio.volume_limit, &min, &max, &gpspeed, buf);
+    Slider("Output volume limit", &g_config.audio.volume_limit, min, max, gpspeed, buf);
 
     SectionTitle("Quality");
     Toggle("Real-time DSP processing", &g_config.audio.use_dsp,

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -70,7 +70,7 @@ void MainMenuGeneralView::Draw()
 
     
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 200), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
-    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf);
+    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed * 2, buf);
 
     if ((g_config.perf.cpu_clockspeed-0.495)*(g_config.perf.cpu_clockspeed-0.505) <= 0) {g_config.perf.cpu_clockspeed = 0.5;}
     

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -66,9 +66,9 @@ void MainMenuGeneralView::Draw()
            "Enables to override default CPU clock speed");
     
     char buf[32];
-    float min* = 0;
-    float max* = 2;
-    float gpspeed* = 0.025;
+    float min = 0;
+    float max = 2;
+    float gpspeed = 0.025;
 
     
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 200), (733333333 * g_config.perf.cpu_clockspeed)/1000000);

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -66,11 +66,13 @@ void MainMenuGeneralView::Draw()
            "Enables to override default CPU clock speed");
     
     char buf[32];
-
+    float min = 0;
+    float max = 2;
+    float gpspeed = 0.025;
 
     
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 200), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
-    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, 0.0f, 2.0f, 0.025f, buf);
+    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, &min , &max, &gpspeed, buf);
 
     if ((g_config.perf.cpu_clockspeed-0.495)*(g_config.perf.cpu_clockspeed-0.505) <= 0) {g_config.perf.cpu_clockspeed = 0.5;}
     
@@ -366,9 +368,12 @@ void MainMenuAudioView::Draw()
 {
     SectionTitle("Volume");
     char buf[32];
+    float min = 0;
+    float max = 2;
+    float gpspeed = 0.05;
     snprintf(buf, sizeof(buf), "Limit output volume (%d%%)",
              (int)(g_config.audio.volume_limit * 100));
-    Slider("Output volume limit", &g_config.audio.volume_limit, buf);
+    Slider("Output volume limit", &g_config.audio.volume_limit, &min, &max, &gpspeed, buf);
 
     SectionTitle("Quality");
     Toggle("Real-time DSP processing", &g_config.audio.use_dsp,

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -66,7 +66,7 @@ void MainMenuGeneralView::Draw()
            "Enables to override default CPU clock speed");
     
     char buf[32];
-    float min = 0;
+    float min = 0.01;
     float max = 2;
     float gpspeed = 0.01;
 

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -70,7 +70,7 @@ void MainMenuGeneralView::Draw()
 
     
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 200), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
-    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed * 2.0, buf);
+    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf * 2 );
 
     if ((g_config.perf.cpu_clockspeed-0.495)*(g_config.perf.cpu_clockspeed-0.505) <= 0) {g_config.perf.cpu_clockspeed = 0.5;}
     

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -68,7 +68,7 @@ void MainMenuGeneralView::Draw()
     char buf[32];
     float min = 0;
     float max = 2;
-    float gpspeed = 0.025;
+    float gpspeed = 0.005;
 
     
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 100), (733333333 * g_config.perf.cpu_clockspeed)/1000000);

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -68,13 +68,13 @@ void MainMenuGeneralView::Draw()
     char buf[32];
     float min = 0;
     float max = 2;
-    float gpspeed = 0.005;
+    float gpspeed = 0.01;
 
     
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 100), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
     Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, min , max, gpspeed, buf);
 
-    if ((g_config.perf.cpu_clockspeed-0.99)*(g_config.perf.cpu_clockspeed-1.01) <= 0) {g_config.perf.cpu_clockspeed = 1;}
+    if ((g_config.perf.cpu_clockspeed-0.999)*(g_config.perf.cpu_clockspeed-1.009) <= 0) {g_config.perf.cpu_clockspeed = 1;}
     
     SectionTitle("Miscellaneous");
     Toggle("Skip startup animation", &g_config.general.skip_boot_anim,

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -71,7 +71,7 @@ void MainMenuGeneralView::Draw()
     float gpspeed = 0.025;
 
     
-    snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 200), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
+    snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 100), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
     Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, min , max, gpspeed, buf);
 
     if ((g_config.perf.cpu_clockspeed-0.495)*(g_config.perf.cpu_clockspeed-0.505) <= 0) {g_config.perf.cpu_clockspeed = 0.5;}

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -70,7 +70,7 @@ void MainMenuGeneralView::Draw()
 
     
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 200), (733333333 * g_config.perf.cpu_clockspeed)/1000000);
-    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, buf , 0f, 2f, 0.025f);
+    Slider("Virtual CPU clock", &g_config.perf.cpu_clockspeed, 0.0f, 2.0f, 0.025f, buf);
 
     if ((g_config.perf.cpu_clockspeed-0.495)*(g_config.perf.cpu_clockspeed-0.505) <= 0) {g_config.perf.cpu_clockspeed = 0.5;}
     

--- a/ui/xui/main-menu.cc
+++ b/ui/xui/main-menu.cc
@@ -66,9 +66,9 @@ void MainMenuGeneralView::Draw()
            "Enables to override default CPU clock speed");
     
     char buf[32];
-    float min = 0;
-    float max = 2;
-    float gpspeed = 0.025;
+    float min* = 0;
+    float max* = 2;
+    float gpspeed* = 0.025;
 
     
     snprintf(buf, sizeof(buf), "Clock Speed %d%% (%.2f MHz)", (int)(g_config.perf.cpu_clockspeed * 200), (733333333 * g_config.perf.cpu_clockspeed)/1000000);

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -224,7 +224,7 @@ bool Toggle(const char *str_id, bool *v, const char *description)
 
 void Slider(const char *str_id, float *v, float min, float max, float gpspeed, const char *description)
 {
-    float* maxpoint = &max
+    float* maxpoint = &max;
     float* x = *v / *maxpoint;
     ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32_BLACK_TRANS);
 

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -222,7 +222,7 @@ bool Toggle(const char *str_id, bool *v, const char *description)
     return status;
 }
 
-void Slider(const char *str_id, float *v, float min = 0.0f, float max = 1.0f, float gpspeed = 0.05f, const char *description)
+void Slider(const char *str_id, float *v, float min, float max, float gpspeed, const char *description)
 {
     ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32_BLACK_TRANS);
 

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -222,7 +222,7 @@ bool Toggle(const char *str_id, bool *v, const char *description)
     return status;
 }
 
-void Slider(const char *str_id, float *v, const char *description)
+void Slider(const char *str_id, float *v, const char *description, float *min, float *max, float *gpspeed)
 {
     ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32_BLACK_TRANS);
 
@@ -261,13 +261,13 @@ void Slider(const char *str_id, float *v, const char *description)
             ImGui::IsKeyPressed(ImGuiKey_GamepadDpadLeft) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadLStickLeft) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadRStickLeft)) {
-                *v -= 0.05;
+                *v -= *gpspeed;
         }
         if (ImGui::IsKeyPressed(ImGuiKey_RightArrow) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadDpadRight) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadLStickRight) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadRStickRight)) {
-                *v += 0.05;
+                *v += *gpspeed;
         }
 
         if (
@@ -288,7 +288,7 @@ void Slider(const char *str_id, float *v, const char *description)
         ImVec2 mouse = ImGui::GetMousePos();
         *v = GetSliderValueForMousePos(mouse, slider_pos, slider_size);
     }
-    *v = fmax(0, fmin(*v, 1));
+    *v = fmax(*min, fmin(*v, *max));
     DrawSlider(*v, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
                slider_size);
 

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -224,7 +224,7 @@ bool Toggle(const char *str_id, bool *v, const char *description)
 
 void Slider(const char *str_id, float v, float min, float max, float gpspeed, const char *description)
 {
-    float x = v/max
+    float x = v/max;
     ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32_BLACK_TRANS);
 
     ImGuiStyle &style = ImGui::GetStyle();
@@ -290,7 +290,7 @@ void Slider(const char *str_id, float v, float min, float max, float gpspeed, co
         x = GetSliderValueForMousePos(mouse, slider_pos, slider_size);
     }
     x = fmax(0, fmin(x, 1));
-    v = fmax(min,fmin(x * max,max))
+    v = fmax(min,fmin(x * max,max));
     DrawSlider(x, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
                slider_size);
 

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -222,8 +222,9 @@ bool Toggle(const char *str_id, bool *v, const char *description)
     return status;
 }
 
-void Slider(const char *str_id, float *v, float min, float max, float gpspeed, const char *description)
+void Slider(const char *str_id, float v, float min, float max, float gpspeed, const char *description)
 {
+    float x = v/max
     ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32_BLACK_TRANS);
 
     ImGuiStyle &style = ImGui::GetStyle();
@@ -261,13 +262,13 @@ void Slider(const char *str_id, float *v, float min, float max, float gpspeed, c
             ImGui::IsKeyPressed(ImGuiKey_GamepadDpadLeft) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadLStickLeft) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadRStickLeft)) {
-                *v -= gpspeed;
+                v -= gpspeed;
         }
         if (ImGui::IsKeyPressed(ImGuiKey_RightArrow) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadDpadRight) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadLStickRight) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadRStickRight)) {
-                *v += gpspeed;
+                v += gpspeed;
         }
 
         if (
@@ -283,13 +284,14 @@ void Slider(const char *str_id, float *v, float min, float max, float gpspeed, c
             ImGui::NavMoveRequestCancel();
         }
     }
-
+    
     if (ImGui::IsItemActive()) {
         ImVec2 mouse = ImGui::GetMousePos();
-        *v = GetSliderValueForMousePos(mouse, slider_pos * max, slider_size);
+        x = GetSliderValueForMousePos(mouse, slider_pos, slider_size);
     }
-    *v = fmax(min, fmin(*v, max));
-    DrawSlider(*v, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
+    x = fmax(0, fmin(x, 1));
+    v = fmax(min,fmin(x * max,max))
+    DrawSlider(x, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
                slider_size);
 
     ImVec2 slider_max = ImVec2(slider_pos.x + slider_size.x, slider_pos.y + slider_size.y);

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -222,7 +222,7 @@ bool Toggle(const char *str_id, bool *v, const char *description)
     return status;
 }
 
-void Slider(const char *str_id, float *v, const char *description, float *min = 0, float *max = 1, float *gpspeed = 0.05)
+void Slider(const char *str_id, float *v, float *min = 0, float *max = 1, float *gpspeed = 0.05, const char *description)
 {
     ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32_BLACK_TRANS);
 

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -222,7 +222,7 @@ bool Toggle(const char *str_id, bool *v, const char *description)
     return status;
 }
 
-void Slider(const char *str_id, float *v, const char *description, float *min, float *max, float *gpspeed)
+void Slider(const char *str_id, float *v, const char *description, float *min = 0, float *max = 1, float *gpspeed = 0.05)
 {
     ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32_BLACK_TRANS);
 

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -286,7 +286,7 @@ void Slider(const char *str_id, float *v, float min, float max, float gpspeed, c
 
     if (ImGui::IsItemActive()) {
         ImVec2 mouse = ImGui::GetMousePos();
-        *v = GetSliderValueForMousePos(mouse, slider_pos, slider_size) / max;
+        *v = GetSliderValueForMousePos(mouse, slider_pos, slider_size);
     }
     *v = fmax(min, fmin(*v, max));
     DrawSlider(*v, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -286,7 +286,7 @@ void Slider(const char *str_id, float *v, float min, float max, float gpspeed, c
 
     if (ImGui::IsItemActive()) {
         ImVec2 mouse = ImGui::GetMousePos();
-        *v = GetSliderValueForMousePos(mouse, slider_pos, slider_size);
+        *v = GetSliderValueForMousePos(mouse, slider_pos, slider_size) / max;
     }
     *v = fmax(min, fmin(*v, max));
     DrawSlider(*v, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -222,7 +222,7 @@ bool Toggle(const char *str_id, bool *v, const char *description)
     return status;
 }
 
-void Slider(const char *str_id, float *v, float *min = 0, float *max = 1, float *gpspeed = 0.05, const char *description)
+void Slider(const char *str_id, float *v, float *min = 0.0f, float *max = 1.0f, float *gpspeed = 0.05f, const char *description)
 {
     ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32_BLACK_TRANS);
 

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -224,8 +224,7 @@ bool Toggle(const char *str_id, bool *v, const char *description)
 
 void Slider(const char *str_id, float *v, float min, float max, float gpspeed, const char *description)
 {
-    float* maxpoint = &max;
-    float* x = *v / *maxpoint;
+    float* x = *v / max;
     ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32_BLACK_TRANS);
 
     ImGuiStyle &style = ImGui::GetStyle();
@@ -291,7 +290,7 @@ void Slider(const char *str_id, float *v, float min, float max, float gpspeed, c
         *x = GetSliderValueForMousePos(mouse, slider_pos, slider_size);
     }
     *x = fmax(0, fmin(*x, 1));
-    *v = fmax(min,fmin(*x * maxpoint,max));
+    *v = fmax(min,fmin(*x * max,max));
     DrawSlider(*x, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
                slider_size);
 

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -286,7 +286,7 @@ void Slider(const char *str_id, float *v, float min, float max, float gpspeed, c
 
     if (ImGui::IsItemActive()) {
         ImVec2 mouse = ImGui::GetMousePos();
-        *v = GetSliderValueForMousePos(mouse, slider_pos, slider_size)/max;
+        *v = GetSliderValueForMousePos(mouse, slider_pos * max, slider_size);
     }
     *v = fmax(min, fmin(*v, max));
     DrawSlider(*v, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -261,13 +261,13 @@ void Slider(const char *str_id, float *v, float min = 0.0f, float max = 1.0f, fl
             ImGui::IsKeyPressed(ImGuiKey_GamepadDpadLeft) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadLStickLeft) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadRStickLeft)) {
-                *v -= *gpspeed;
+                *v -= gpspeed;
         }
         if (ImGui::IsKeyPressed(ImGuiKey_RightArrow) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadDpadRight) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadLStickRight) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadRStickRight)) {
-                *v += *gpspeed;
+                *v += gpspeed;
         }
 
         if (
@@ -288,7 +288,7 @@ void Slider(const char *str_id, float *v, float min = 0.0f, float max = 1.0f, fl
         ImVec2 mouse = ImGui::GetMousePos();
         *v = GetSliderValueForMousePos(mouse, slider_pos, slider_size);
     }
-    *v = fmax(*min, fmin(*v, *max));
+    *v = fmax(min, fmin(*v, max));
     DrawSlider(*v, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
                slider_size);
 

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -224,7 +224,7 @@ bool Toggle(const char *str_id, bool *v, const char *description)
 
 void Slider(const char *str_id, float *v, float min, float max, float gpspeed, const char *description)
 {
-    float* x = *v / max;
+    float x = *v / max;
     ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32_BLACK_TRANS);
 
     ImGuiStyle &style = ImGui::GetStyle();

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -287,11 +287,11 @@ void Slider(const char *str_id, float *v, float min, float max, float gpspeed, c
     
     if (ImGui::IsItemActive()) {
         ImVec2 mouse = ImGui::GetMousePos();
-        *x = GetSliderValueForMousePos(mouse, slider_pos, slider_size);
+        x = GetSliderValueForMousePos(mouse, slider_pos, slider_size);
     }
-    *x = fmax(0, fmin(*x, 1));
-    *v = fmax(min,fmin(*x * max,max));
-    DrawSlider(*x, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
+    x = fmax(0, fmin(x, 1));
+    *v = fmax(min,fmin(x * max,max));
+    DrawSlider(x, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
                slider_size);
 
     ImVec2 slider_max = ImVec2(slider_pos.x + slider_size.x, slider_pos.y + slider_size.y);

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -222,9 +222,10 @@ bool Toggle(const char *str_id, bool *v, const char *description)
     return status;
 }
 
-void Slider(const char *str_id, float v, float min, float max, float gpspeed, const char *description)
+void Slider(const char *str_id, float *v, float min, float max, float gpspeed, const char *description)
 {
-    float x = v/max;
+    float* maxpoint = &max
+    float* x = *v / *maxpoint;
     ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32_BLACK_TRANS);
 
     ImGuiStyle &style = ImGui::GetStyle();
@@ -262,13 +263,13 @@ void Slider(const char *str_id, float v, float min, float max, float gpspeed, co
             ImGui::IsKeyPressed(ImGuiKey_GamepadDpadLeft) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadLStickLeft) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadRStickLeft)) {
-                v -= gpspeed;
+                *v -= gpspeed;
         }
         if (ImGui::IsKeyPressed(ImGuiKey_RightArrow) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadDpadRight) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadLStickRight) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadRStickRight)) {
-                v += gpspeed;
+                *v += gpspeed;
         }
 
         if (
@@ -287,11 +288,11 @@ void Slider(const char *str_id, float v, float min, float max, float gpspeed, co
     
     if (ImGui::IsItemActive()) {
         ImVec2 mouse = ImGui::GetMousePos();
-        x = GetSliderValueForMousePos(mouse, slider_pos, slider_size);
+        *x = GetSliderValueForMousePos(mouse, slider_pos, slider_size);
     }
-    x = fmax(0, fmin(x, 1));
-    v = fmax(min,fmin(x * max,max));
-    DrawSlider(x, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
+    *x = fmax(0, fmin(*x, 1));
+    *v = fmax(min,fmin(*x * maxpoint,max));
+    DrawSlider(*x, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
                slider_size);
 
     ImVec2 slider_max = ImVec2(slider_pos.x + slider_size.x, slider_pos.y + slider_size.y);

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -286,14 +286,14 @@ void Slider(const char *str_id, float *v, float min, float max, float gpspeed, c
 
     if (ImGui::IsItemActive()) {
         ImVec2 mouse = ImGui::GetMousePos();
-        *v = GetSliderValueForMousePos(mouse, slider_pos, slider_size);
+        *v = GetSliderValueForMousePos(mouse, slider_pos, slider_size)/max;
     }
-    *v = fmax(min, fmin(*v, max));
+    *v = fmax(0, fmin(*v, 1));
     DrawSlider(*v, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
                slider_size);
 
     ImVec2 slider_max = ImVec2(slider_pos.x + slider_size.x, slider_pos.y + slider_size.y);
-    ImGui::RenderNavHighlight(ImRect(slider_pos, slider_max, window->GetID("###slider"));
+    ImGui::RenderNavHighlight(ImRect(slider_pos, slider_max), window->GetID("###slider"));
 
     ImGui::PopStyleColor();
 }

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -262,13 +262,13 @@ void Slider(const char *str_id, float *v, float min, float max, float gpspeed, c
             ImGui::IsKeyPressed(ImGuiKey_GamepadDpadLeft) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadLStickLeft) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadRStickLeft)) {
-                *v -= gpspeed;
+                x -= gpspeed * max;
         }
         if (ImGui::IsKeyPressed(ImGuiKey_RightArrow) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadDpadRight) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadLStickRight) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadRStickRight)) {
-                *v += gpspeed;
+                x += gpspeed * max;
         }
 
         if (

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -292,8 +292,8 @@ void Slider(const char *str_id, float *v, float min, float max, float gpspeed, c
     DrawSlider(*v, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
                slider_size);
 
-    ImVec2 slider_max = ImVec2((slider_pos.x / max) + slider_size.x, slider_pos.y + slider_size.y);
-    ImGui::RenderNavHighlight(ImRect(slider_pos, slider_max), window->GetID("###slider"));
+    ImVec2 slider_max = ImVec2(slider_pos.x + slider_size.x, slider_pos.y + slider_size.y);
+    ImGui::RenderNavHighlight(ImRect(slider_pos, (slider_max / max)), window->GetID("###slider"));
 
     ImGui::PopStyleColor();
 }

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -289,7 +289,7 @@ void Slider(const char *str_id, float *v, float min, float max, float gpspeed, c
         *v = GetSliderValueForMousePos(mouse, slider_pos, slider_size);
     }
     *v = fmax(min, fmin(*v, max));
-    DrawSlider((*v / max), ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
+    DrawSlider(*v, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
                slider_size);
 
     ImVec2 slider_max = ImVec2(slider_pos.x + slider_size.x, slider_pos.y + slider_size.y);

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -262,13 +262,13 @@ void Slider(const char *str_id, float *v, float min, float max, float gpspeed, c
             ImGui::IsKeyPressed(ImGuiKey_GamepadDpadLeft) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadLStickLeft) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadRStickLeft)) {
-                x -= gpspeed * max;
+                x -= gpspeed / max;
         }
         if (ImGui::IsKeyPressed(ImGuiKey_RightArrow) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadDpadRight) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadLStickRight) ||
             ImGui::IsKeyPressed(ImGuiKey_GamepadRStickRight)) {
-                x += gpspeed * max;
+                x += gpspeed / max;
         }
 
         if (

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -289,11 +289,11 @@ void Slider(const char *str_id, float *v, float min, float max, float gpspeed, c
         *v = GetSliderValueForMousePos(mouse, slider_pos, slider_size);
     }
     *v = fmax(min, fmin(*v, max));
-    DrawSlider(*v, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
+    DrawSlider((*v / max), ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
                slider_size);
 
     ImVec2 slider_max = ImVec2(slider_pos.x + slider_size.x, slider_pos.y + slider_size.y);
-    ImGui::RenderNavHighlight(ImRect(slider_pos, (slider_max / max)), window->GetID("###slider"));
+    ImGui::RenderNavHighlight(ImRect(slider_pos, slider_max, window->GetID("###slider"));
 
     ImGui::PopStyleColor();
 }

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -288,7 +288,7 @@ void Slider(const char *str_id, float *v, float min, float max, float gpspeed, c
         ImVec2 mouse = ImGui::GetMousePos();
         *v = GetSliderValueForMousePos(mouse, slider_pos, slider_size)/max;
     }
-    *v = fmax(0, fmin(*v, 1));
+    *v = fmax(min, fmin(*v, max));
     DrawSlider(*v, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
                slider_size);
 

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -222,7 +222,7 @@ bool Toggle(const char *str_id, bool *v, const char *description)
     return status;
 }
 
-void Slider(const char *str_id, float *v, float *min = 0.0f, float *max = 1.0f, float *gpspeed = 0.05f, const char *description)
+void Slider(const char *str_id, float *v, float min = 0.0f, float max = 1.0f, float gpspeed = 0.05f, const char *description)
 {
     ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32_BLACK_TRANS);
 

--- a/ui/xui/widgets.cc
+++ b/ui/xui/widgets.cc
@@ -292,7 +292,7 @@ void Slider(const char *str_id, float *v, float min, float max, float gpspeed, c
     DrawSlider(*v, ImGui::IsItemHovered() || ImGui::IsItemActive(), slider_pos,
                slider_size);
 
-    ImVec2 slider_max = ImVec2(slider_pos.x + slider_size.x, slider_pos.y + slider_size.y);
+    ImVec2 slider_max = ImVec2((slider_pos.x / max) + slider_size.x, slider_pos.y + slider_size.y);
     ImGui::RenderNavHighlight(ImRect(slider_pos, slider_max), window->GetID("###slider"));
 
     ImGui::PopStyleColor();

--- a/ui/xui/widgets.hh
+++ b/ui/xui/widgets.hh
@@ -34,7 +34,7 @@ float GetSliderValueForMousePos(ImVec2 mouse, ImVec2 pos, ImVec2 size);
 void DrawSlider(float v, bool hovered, ImVec2 pos, ImVec2 size);
 void DrawToggle(bool enabled, bool hovered, ImVec2 pos, ImVec2 size);
 bool Toggle(const char *str_id, bool *v, const char *description = nullptr);
-void Slider(const char *str_id, float *v, const char *description = nullptr, float *min = 0, float *max = 1, float *gpspeed = 0.05);
+void Slider(const char *str_id, float *v, const char *description = nullptr, float *min = 0f, float *max = 1f, float *gpspeed = 0.05f);
 bool FilePicker(const char *str_id, const char **buf, const char *filters,
                 bool dir = false);
 void DrawComboChevron();

--- a/ui/xui/widgets.hh
+++ b/ui/xui/widgets.hh
@@ -34,7 +34,7 @@ float GetSliderValueForMousePos(ImVec2 mouse, ImVec2 pos, ImVec2 size);
 void DrawSlider(float v, bool hovered, ImVec2 pos, ImVec2 size);
 void DrawToggle(bool enabled, bool hovered, ImVec2 pos, ImVec2 size);
 bool Toggle(const char *str_id, bool *v, const char *description = nullptr);
-void Slider(const char *str_id, float *v, float *min, float *max, float *gpspeed, const char *description = nullptr);
+void Slider(const char *str_id, float *v, float min, float max, float gpspeed, const char *description = nullptr);
 bool FilePicker(const char *str_id, const char **buf, const char *filters,
                 bool dir = false);
 void DrawComboChevron();

--- a/ui/xui/widgets.hh
+++ b/ui/xui/widgets.hh
@@ -34,7 +34,7 @@ float GetSliderValueForMousePos(ImVec2 mouse, ImVec2 pos, ImVec2 size);
 void DrawSlider(float v, bool hovered, ImVec2 pos, ImVec2 size);
 void DrawToggle(bool enabled, bool hovered, ImVec2 pos, ImVec2 size);
 bool Toggle(const char *str_id, bool *v, const char *description = nullptr);
-void Slider(const char *str_id, float *v, const char *description = nullptr, float *min, float *max, float *gpspeed);
+void Slider(const char *str_id, float *v, , float *min, float *max, float *gpspeed, const char *description = nullptr);
 bool FilePicker(const char *str_id, const char **buf, const char *filters,
                 bool dir = false);
 void DrawComboChevron();

--- a/ui/xui/widgets.hh
+++ b/ui/xui/widgets.hh
@@ -34,7 +34,7 @@ float GetSliderValueForMousePos(ImVec2 mouse, ImVec2 pos, ImVec2 size);
 void DrawSlider(float v, bool hovered, ImVec2 pos, ImVec2 size);
 void DrawToggle(bool enabled, bool hovered, ImVec2 pos, ImVec2 size);
 bool Toggle(const char *str_id, bool *v, const char *description = nullptr);
-void Slider(const char *str_id, float *v, const char *description = nullptr, float *min = 0f, float *max = 1f, float *gpspeed = 0.05f);
+void Slider(const char *str_id, float *v, const char *description = nullptr, float *min = 0, float *max = 1, float *gpspeed = 0.05);
 bool FilePicker(const char *str_id, const char **buf, const char *filters,
                 bool dir = false);
 void DrawComboChevron();

--- a/ui/xui/widgets.hh
+++ b/ui/xui/widgets.hh
@@ -34,7 +34,7 @@ float GetSliderValueForMousePos(ImVec2 mouse, ImVec2 pos, ImVec2 size);
 void DrawSlider(float v, bool hovered, ImVec2 pos, ImVec2 size);
 void DrawToggle(bool enabled, bool hovered, ImVec2 pos, ImVec2 size);
 bool Toggle(const char *str_id, bool *v, const char *description = nullptr);
-void Slider(const char *str_id, float *v, const char *description = nullptr, float *min, float *max, float *gpspeed);
+void Slider(const char *str_id, float *v, const char *description = nullptr, float *min = 0, float *max = 1, float *gpspeed = 0.05);
 bool FilePicker(const char *str_id, const char **buf, const char *filters,
                 bool dir = false);
 void DrawComboChevron();

--- a/ui/xui/widgets.hh
+++ b/ui/xui/widgets.hh
@@ -34,7 +34,7 @@ float GetSliderValueForMousePos(ImVec2 mouse, ImVec2 pos, ImVec2 size);
 void DrawSlider(float v, bool hovered, ImVec2 pos, ImVec2 size);
 void DrawToggle(bool enabled, bool hovered, ImVec2 pos, ImVec2 size);
 bool Toggle(const char *str_id, bool *v, const char *description = nullptr);
-void Slider(const char *str_id, float *v, const char *description = nullptr, float *min = 0, float *max = 1, float *gpspeed = 0.05);
+void Slider(const char *str_id, float *v, const char *description = nullptr, float *min, float *max, float *gpspeed);
 bool FilePicker(const char *str_id, const char **buf, const char *filters,
                 bool dir = false);
 void DrawComboChevron();

--- a/ui/xui/widgets.hh
+++ b/ui/xui/widgets.hh
@@ -34,7 +34,7 @@ float GetSliderValueForMousePos(ImVec2 mouse, ImVec2 pos, ImVec2 size);
 void DrawSlider(float v, bool hovered, ImVec2 pos, ImVec2 size);
 void DrawToggle(bool enabled, bool hovered, ImVec2 pos, ImVec2 size);
 bool Toggle(const char *str_id, bool *v, const char *description = nullptr);
-void Slider(const char *str_id, float *v, float min, float max, float gpspeed, const char *description = nullptr);
+void Slider(const char *str_id, float v, float min, float max, float gpspeed, const char *description = nullptr);
 bool FilePicker(const char *str_id, const char **buf, const char *filters,
                 bool dir = false);
 void DrawComboChevron();

--- a/ui/xui/widgets.hh
+++ b/ui/xui/widgets.hh
@@ -34,7 +34,7 @@ float GetSliderValueForMousePos(ImVec2 mouse, ImVec2 pos, ImVec2 size);
 void DrawSlider(float v, bool hovered, ImVec2 pos, ImVec2 size);
 void DrawToggle(bool enabled, bool hovered, ImVec2 pos, ImVec2 size);
 bool Toggle(const char *str_id, bool *v, const char *description = nullptr);
-void Slider(const char *str_id, float v, float min, float max, float gpspeed, const char *description = nullptr);
+void Slider(const char *str_id, float *v, float min, float max, float gpspeed, const char *description = nullptr);
 bool FilePicker(const char *str_id, const char **buf, const char *filters,
                 bool dir = false);
 void DrawComboChevron();

--- a/ui/xui/widgets.hh
+++ b/ui/xui/widgets.hh
@@ -34,7 +34,7 @@ float GetSliderValueForMousePos(ImVec2 mouse, ImVec2 pos, ImVec2 size);
 void DrawSlider(float v, bool hovered, ImVec2 pos, ImVec2 size);
 void DrawToggle(bool enabled, bool hovered, ImVec2 pos, ImVec2 size);
 bool Toggle(const char *str_id, bool *v, const char *description = nullptr);
-void Slider(const char *str_id, float *v, , float *min, float *max, float *gpspeed, const char *description = nullptr);
+void Slider(const char *str_id, float *v, float *min, float *max, float *gpspeed, const char *description = nullptr);
 bool FilePicker(const char *str_id, const char **buf, const char *filters,
                 bool dir = false);
 void DrawComboChevron();

--- a/ui/xui/widgets.hh
+++ b/ui/xui/widgets.hh
@@ -34,7 +34,7 @@ float GetSliderValueForMousePos(ImVec2 mouse, ImVec2 pos, ImVec2 size);
 void DrawSlider(float v, bool hovered, ImVec2 pos, ImVec2 size);
 void DrawToggle(bool enabled, bool hovered, ImVec2 pos, ImVec2 size);
 bool Toggle(const char *str_id, bool *v, const char *description = nullptr);
-void Slider(const char *str_id, float *v, const char *description = nullptr);
+void Slider(const char *str_id, float *v, const char *description = nullptr, float *min, float *max, float *gpspeed);
 bool FilePicker(const char *str_id, const char **buf, const char *filters,
                 bool dir = false);
 void DrawComboChevron();


### PR DESCRIPTION
This adds a minimum and maximum and gamepad speed values to change the behavior of the slider. 

This change included separating slider value and the properties value for the actual setting because increasing the sliders clamp also keeps the slider handle in the right position and if increased it will allow outside of the slider range. So using some math I was able to make the slider keep its range while also making the value change appropriately. 

Adding gamepad speed allowed for better fine control of the slider for certain sliders if needed. Minimum and maximum is value ranges that can be set when making a slider. In this commit I also slightly adjusted the notch when hitting 100% so that the gamepad can escape it. This also has been tested with audio to work like before and can even increase the range it can do even if audio won’t go higher but just proves that it Infact changes the range.